### PR TITLE
removing namespace/comment on ingress

### DIFF
--- a/manifests/ingress.yaml
+++ b/manifests/ingress.yaml
@@ -5,9 +5,8 @@ items:
     kind: Ingress
     metadata:
       name: metrics-demo
-      namespace: ide-workspace
       annotations:
-        kubernetes.io/ingress.class: traefik
+        kubernetes.io/ingress.class: traefik #default for minikube is nginx
     spec:
       rules:
       - http:


### PR DESCRIPTION
as it was the only place listing one, and comment for nginx ingress